### PR TITLE
Update LICENSE file to correct package name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,9 @@
-UGALY is free software; you can redistribute and/or modify
+SRGroups is free software; you can redistribute and/or modify
 it under the terms of the GNU General Public License as published by
 the Free Software Foundation; either version 3 of the License, or (at
 your option) any later version.
 
-UGALY is distributed in the hope that it will be useful, 
+SRGroups is distributed in the hope that it will be useful, 
 but WITHOUT ANY WARRANTY; without even the implied warranty of 
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 General Public License for more details.


### PR DESCRIPTION
The licence file included the name of the package it was presumably copied from, so this update changes that to "SRGroups", the current package.